### PR TITLE
Handle PlayActivity resume() to not crash

### DIFF
--- a/app/src/main/java/pl/tlasica/firewire/GameView.java
+++ b/app/src/main/java/pl/tlasica/firewire/GameView.java
@@ -30,14 +30,11 @@ public class GameView extends SurfaceView implements SurfaceHolder.Callback {
         }
     }
 
-    public Game getGame() {
-        return game;
-    }
-
     @Override
     public void surfaceCreated(SurfaceHolder holder) {
         Log.d("SURFACE", "Created");
         if (game != null) {
+            Log.d("SURFACE", "Game was not null. Create() and start()");
             game.create(holder, events);
             game.start();
         }

--- a/app/src/main/java/pl/tlasica/firewire/PlayActivity.java
+++ b/app/src/main/java/pl/tlasica/firewire/PlayActivity.java
@@ -29,11 +29,11 @@ import pl.tlasica.firewire.play.Player;
 //https://developer.android.com/guide/topics/ui/dialogs.html
 
 public class PlayActivity extends BasicActivity {
-    private GameView    mGameView;
     private TextView    mTimeView;
     private CountDownTimer timer;
     private String      addUnitId = "ca-app-pub-6316552100242193/6643259663";
     InterstitialAd      mInterstitialAd;
+    Game                game;
 
     private static int  playNextCounter = 0;
     private static int  showAddCounterBarrier = 3;
@@ -65,8 +65,8 @@ public class PlayActivity extends BasicActivity {
         // start countdown timer to stop game and update time
         timer = startTimer();
         // start game
-        mGameView = (GameView)findViewById(R.id.game_view);
-        mGameView.setGame(new Game(this));
+        game = new Game(this);
+        this.setGameInGameView();
     }
 
 
@@ -80,8 +80,11 @@ public class PlayActivity extends BasicActivity {
 
     @Override
     protected void onResume() {
+        Log.i("PLAYACT", "onResume()");
         super.onResume();
         fullScreenMode();
+        this.game = new Game(this);
+        this.setGameInGameView();
     }
 
     private void fullScreenMode() {
@@ -164,9 +167,7 @@ public class PlayActivity extends BasicActivity {
     }
 
     private Game game() {
-        GameView gameView = (GameView)findViewById(R.id.game_view);
-        Game game = gameView.getGame();
-        return game;
+        return this.game;
     }
 
     public void nextLevel() {
@@ -248,7 +249,15 @@ public class PlayActivity extends BasicActivity {
         timer = startTimer();
         TextView titleText = (TextView)findViewById(R.id.level_title);
         titleText.setText(LevelPlay.current().board.title);
-        mGameView.setGame(new Game(this));
+        game = new Game(this);
+        this.setGameInGameView();
         game().start();
+    }
+
+    private void setGameInGameView() {
+        GameView gameView = (GameView)findViewById(R.id.game_view);
+        if (gameView != null) {
+            gameView.setGame(game);
+        }
     }
 }

--- a/app/src/main/java/pl/tlasica/firewire/play/Game.java
+++ b/app/src/main/java/pl/tlasica/firewire/play/Game.java
@@ -99,8 +99,10 @@ public class Game {
     }
 
     public void start() {
-        Log.i("", "Game started");
-        thread.start();
+        Log.i("Game", "start()");
+        if (thread.getState() == Thread.State.NEW) {
+            thread.start();
+        }
     }
 
     public void stop() {
@@ -122,8 +124,15 @@ public class Game {
 
     public void create(SurfaceHolder surfaceHolder, Queue<MouseEvent> eventsQueue) {
         Log.i("Game", "create()");
-        gameLoop = new GameLoop(this, surfaceHolder, eventsQueue);
-        thread = new Thread(gameLoop);
+        if (gameLoop == null) {
+            Log.i("Game", "gameLoop was null -> starting.");
+            gameLoop = new GameLoop(this, surfaceHolder, eventsQueue);
+            thread = new Thread(gameLoop);
+        }
+        else {
+            Log.i("Game", "gameLoop was not null -> updating");
+
+        }
     }
 
 }


### PR DESCRIPTION
It was quite easy to crash: just choose "square" on emulator and then when app is sent to back do it again to bring it back. Expected behavior is to continue game, but in PlayActivity it was simply crashing due to problems with surfaceHolder.
